### PR TITLE
Do not check OpenSSL version since TLS v1.0 is supported.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "payplug/payplug-php",
   "description": "A simple PHP library for PayPlug public API.",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "type": "library",
   "homepage": "https://www.payplug.com",
   "time": "2015-05-06",

--- a/lib/Payplug/Core/Config.php
+++ b/lib/Payplug/Core/Config.php
@@ -10,7 +10,7 @@ class Config
     /**
      * The library version
      */
-    const LIBRARY_VERSION = '2.2.0';
+    const LIBRARY_VERSION = '2.2.1';
 
     /**
      * PHP minimal version required by this library
@@ -37,14 +37,6 @@ class Config
 // Check PHP version
 if (version_compare(phpversion(), Config::PHP_MIN_VERSION, "<")) {
     throw new \RuntimeException('This library requires PHP ' . Config::PHP_MIN_VERSION . ' or newer.');
-}
-
-// Check OpenSSL version
-// http://blog.techstacks.com/2013/04/an-openssl-version-matrix.html
-if (defined('OPENSSL_VERSION_NUMBER') && OPENSSL_VERSION_NUMBER < 0x10001001) {
-    throw new Exception\DependencyException(
-        'This library requires OpenSSL 1.0.1 or newer. Please contact your webhoster or update your OpenSSL version.'
-    );
 }
 
 // Check PHP configuration

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -5,7 +5,7 @@ Prerequisites:
 Download composer and update dev dependencies.
 ::
 
-    php composer.phar update --require-dev
+    php composer.phar update
 
 Run the recommended tests:
 --------------------------


### PR DESCRIPTION
Remove incorrect require-dev option in tests README.