### PR TITLE
Add isset magic method to resources

### DIFF
--- a/lib/Payplug/Resource/APIResource.php
+++ b/lib/Payplug/Resource/APIResource.php
@@ -76,12 +76,25 @@ abstract class APIResource implements IAPIResourceFactory
      */
     public function __get($attribute)
     {
-        if (array_key_exists($attribute, $this->_attributes)) {
+        if ($this->__isset($attribute)) {
             return $this->_attributes[$attribute];
         }
 
         throw new Payplug\Exception\UndefinedAttributeException('Requested attribute ' . $attribute . ' is undefined.');
     }
+
+    /**
+     * Checks if an API resource property is set
+     *
+     * @param   string  $attribute  the key of the attribute to check
+     *
+     * @return  bool    True if the property is set. False otherwise.
+     */
+    public function __isset($attribute)
+    {
+        return array_key_exists($attribute, $this->_attributes);
+    }
+
 
     /**
      * Sets an API resource property.

--- a/tests/unit_tests/Resource/APIResourceTest.php
+++ b/tests/unit_tests/Resource/APIResourceTest.php
@@ -34,6 +34,16 @@ class APIResourceTest extends \PHPUnit_Framework_TestCase
         $this->_myApiResource->an_undefined_attribute;
     }
 
+    public function testIssetReturnsTrueWhenPropertyExists()
+    {
+        $this->assertTrue(isset($this->_myApiResource->attr1));
+    }
+
+    public function testIssetReturnsFalseWhenPropertyDoesNotExist()
+    {
+        $this->assertFalse(isset($this->_myApiResource->an_undefined_attribute));
+    }
+
     public function testPaymentFromAPIResourceFactory()
     {
         $attributes = array(


### PR DESCRIPTION
Hi there,

Twig needs the __isset magic method to be defined in order to access properties of the resource. See http://twig.sensiolabs.org/doc/recipes.html#using-dynamic-object-properties

Adding this method will allow me to display payment information in admin page of my website.
