### PR TITLE
Don't specify version in composer.json.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
   "name": "payplug/payplug-php",
   "description": "A simple PHP library for PayPlug public API.",
-  "version": "2.4.0",
   "type": "library",
   "homepage": "https://www.payplug.com",
   "time": "2015-05-06",


### PR DESCRIPTION
This is to avoid mistakes when releasing new versions. Packagist should
deduce the version from the tag.