### PR TITLE
feat: PRE-1935: add call to MPDC microservice

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,14 +10,14 @@ PHP library for the Payplug API
    :alt: Packagist
 
 This is the documentation of Payplug's PHP library. It is designed to
-help developers to use Payplug as payment solution in a simple, yet robust way.
+help developers use Payplug as a payment solution in a simple, yet robust way.
 
 You can create a Payplug account at https://www.payplug.com/.
 
 Maintenance
--------------
+-----------
 
-CA certificate (cacert.pem) should be updated every year during the first week of December. 
+CA certificate (cacert.pem) should be updated every year during the first week of December.
 Go to https://curl.se/docs/caextract.html to get a recent one.
 
 Prerequisites
@@ -25,28 +25,31 @@ Prerequisites
 
 Payplug's library relies on **cURL** to perform HTTP requests and requires **OpenSSL (1.0.1 or newer)** to secure transactions. You also need **PHP 5.3** or newer for the Payplug PHP V2.
 
-For version **PHP 5.2** or older you must refer to Payplug PHP V1.
+For version **PHP 5.2** or older, you must refer to Payplug PHP V1.
 
 Documentation
 -------------
-Please see https://docs.payplug.com/api for latest documentation.
+
+Please see https://docs.payplug.com/api for the latest documentation.
 
 Installation
-------------
+-------------
+
 **Option 1 - Strongly preferred)** via composer:
 
-- Get composer from `composer website`_.
+- Get composer from the `composer website`_.
 - Make sure you have initialized your *composer.json*.
 - Run *composer require payplug/payplug-php* from your project directory.
 
 .. _composer website: https://getcomposer.org/download/
 
-**Option 2)** clone the repository :
+**Option 2-** clone the repository:
+
 ::
 
     git clone https://github.com/payplug/payplug-php.git
 
-**Option 3)** download as a tarball :
+**Option 3)** download as a tarball:
 
 - Download the most recent tarball from the `download page V2`_ (V2 for **PHP 5.3** or newer)
 - Download the most recent tarball from the `download page V1`_ (V1 for **PHP 5.2** or older)
@@ -60,17 +63,80 @@ __ https://bitbucket.org/payplug/payplug_php/downloads#tag-downloads
 
 To get started, add the following to your PHP script (if you are not running a framework):
 
-.. sourcecode :: php
+.. code-block:: php
 
     <?php
     require_once("PATH_TO_PAYPLUG/payplug_php/lib/init.php");
+
+Project Git Workflow
+=====================
+
+This repository follows a specific Git workflow to ensure smooth collaboration and controlled releases. Please follow the steps outlined below when contributing to this project.
+
+Git Workflow Steps
+------------------
+
+1. **Create a feature or fix branch:**
+
+   Before making any changes, create a new branch from the `develop` branch:
+
+   ::
+
+       git checkout develop
+       git pull origin develop
+       git checkout -b <feature-name>
+
+   For a bug fix, use:
+
+   ::
+
+       git checkout develop
+       git pull origin develop
+       git checkout -b <fix-name>
+
+2. **Work on your feature or fix:**
+
+   Make your code changes and commit them to your feature or fix branch.
+
+3. **Create a merge request:**
+
+   Once your feature or fix is ready, create a merge request from your branch to the `develop` branch. Get your changes reviewed by your peers.
+
+4. **Release preparation:**
+
+   When it's time for a release, create an intermediary branch called `release-<version-number>` from the `develop` branch:
+
+   ::
+
+       git checkout develop
+       git pull origin develop
+       git checkout -b release-<version-number>
+
+5. **Finalize the release:**
+
+   Test the code on the `release-<version-number>` branch thoroughly. Fix any bugs or issues that arise.
+
+6. **Merge to master:**
+
+   Once the release is tested and stable, create a merge request from the `release-<version-number>` branch to the `master` branch. This signifies a successful release.
+
+7. **Tag the release:**
+
+   After the merge to `master`, create a new tag to mark the release version:
+
+   ::
+
+       git checkout master
+       git pull origin master
+       git tag -a v<version-number> -m "Release <version-number>"
+       git push origin master --tags
 
 Usage
 -----
 
 Here's how simple it is to create a payment request:
 
-.. sourcecode :: php
+.. code-block:: php
 
     <?php
     require_once("PATH_TO_PAYPLUG/payplug_php/lib/init.php"); // If not using a framework
@@ -82,7 +148,7 @@ Here's how simple it is to create a payment request:
     ));
 
     // Create a payment request of €9.99. The payment confirmation (IPN) will be sent to "'https://example.net/notifications?id='.$customer_id".
-    // note that all amounts must be expressed in centimes as positive whole numbers (€9.99 = 999 centimes).
+    // Note that all amounts must be expressed in centimes as positive whole numbers (€9.99 = 999 centimes).
     // Metadata allow you to include additional information when processing payments or refunds.
     $customer_id = '42710';
 
@@ -121,10 +187,9 @@ Here's how simple it is to create a payment request:
                 'customer_id'  => $customer_id
             )
     ));
-    ?>
 
     // You will be able to find how the payment object is built in the documentation.
-    // For instance, if you want to get an URL to the payment page, you get do:
+    // For instance, if you want to get a URL to the payment page, you can do:
     $paymentUrl = $payment->hosted_payment->payment_url;
 
     // Then, you can redirect the user to the payment page
@@ -135,3 +200,16 @@ Go further:
 Tests:
 ++++++
 See tests/README.rst.
+
+Project Owners
+--------------
+
+This project is maintained by:
+
+
+- [Imène Lajili](https://github.com/ilajili)
+- [Manuel Mesquita](https://github.com/PPmmesquita)
+
+For any questions or concerns about the workflow, feel free to reach out to the project owners.
+
+

--- a/lib/Payplug/Core/APIRoutes.php
+++ b/lib/Payplug/Core/APIRoutes.php
@@ -13,6 +13,11 @@ class APIRoutes
      */
     public static $API_BASE_URL;
 
+    /**
+     * @var string the root URL of the MPDC microService
+     */
+    public static $MERCHANT_PLUGINS_DATA_COLLECTOR_RESOURCE;
+
     const API_VERSION = 1;
 
     // Resources routes
@@ -25,6 +30,7 @@ class APIRoutes
     const ONEY_PAYMENT_SIM_RESOURCE  = '/oney_payment_simulations';
     const ACCOUNTING_REPORT_RESOURCE = '/accounting_reports';
     const PUBLISHABLE_KEYS           = '/publishable_keys';
+
 
 
     /**
@@ -63,6 +69,15 @@ class APIRoutes
     }
 
     /**
+     * @description set $MERCHANT_PLUGINS_DATA_COLLECTOR_RESOURCE from plugin
+     * @param $microServiceBaseUrl
+     */
+    public static function setMerchantPluginsDataCollectorService($microServiceBaseUrl)
+    {
+        self::$MERCHANT_PLUGINS_DATA_COLLECTOR_RESOURCE = $microServiceBaseUrl;
+    }
+
+    /**
      * Gets a route that allows to check whether the remote API is up.
      *
      * @return  string  the full URL to the test resource
@@ -74,4 +89,5 @@ class APIRoutes
 }
 
 APIRoutes::$API_BASE_URL = 'https://api.payplug.com';
+APIRoutes::$MERCHANT_PLUGINS_DATA_COLLECTOR_RESOURCE = 'Microservice Url';
 

--- a/lib/Payplug/Core/HttpClient.php
+++ b/lib/Payplug/Core/HttpClient.php
@@ -348,6 +348,10 @@ class HttpClient
                 throw new Payplug\Exception\NotAllowedException('The requested method is not supported by this resource.',
                     $httpResponse, $httpStatus);
                 break;
+            case 422:
+                throw new Payplug\Exception\UnprocessableEntityException('The server encountered an error while processing the request. The submitted data could not be processed.',
+                     $httpResponse, $httpStatus);
+                break;
         }
 
         throw new Payplug\Exception\HttpException('Unhandled HTTP error.', $httpResponse, $httpStatus);

--- a/lib/Payplug/Exception/UnprocessableEntityException.php
+++ b/lib/Payplug/Exception/UnprocessableEntityException.php
@@ -1,0 +1,12 @@
+<?php
+
+
+namespace Payplug\Exception;
+
+/**
+ * 422 Unprocessed Entity
+ */
+class UnprocessableEntityException extends HttpException
+{
+
+}

--- a/lib/Payplug/PluginTelemetry.php
+++ b/lib/Payplug/PluginTelemetry.php
@@ -1,0 +1,38 @@
+<?php
+
+
+namespace Payplug;
+use Payplug;
+
+
+/**
+ * sent Data to Merchant Plugins Data Collector
+ * Class PluginTelemetry
+ * @package Payplug
+ */
+class PluginTelemetry
+{
+
+    /**
+     *
+     * Send data to Merchant Plugins Data Collector Micro Service
+     *
+     * @param array $data
+     * @param \Payplug\Payplug|null $payplug
+     * @return array|false|Core\CurlRequest|Core\IHttpRequest|null
+     * @throws Exception\ConnectionException
+     * @throws Exception\HttpException
+     * @throws Exception\UnexpectedAPIResponseException
+     */
+    public static function send(array $data,  Payplug\Payplug $payplug = null) {
+
+        $httpClient = new Payplug\Core\HttpClient();
+
+        return $response = $httpClient->post(
+            Payplug\Core\APIRoutes::$MERCHANT_PLUGINS_DATA_COLLECTOR_RESOURCE,
+            $data,
+            false
+        );
+
+    }
+}

--- a/lib/Payplug/PluginTelemetry.php
+++ b/lib/Payplug/PluginTelemetry.php
@@ -13,19 +13,20 @@ use Payplug;
 class PluginTelemetry
 {
 
+
     /**
-     *
      * Send data to Merchant Plugins Data Collector Micro Service
      *
-     * @param array $data
+     * @param string $data
      * @param \Payplug\Payplug|null $payplug
-     * @return array|false|Core\CurlRequest|Core\IHttpRequest|null
+     * @return array
      * @throws Exception\ConnectionException
      * @throws Exception\HttpException
      * @throws Exception\UnexpectedAPIResponseException
      */
-    public static function send(array $data,  Payplug\Payplug $payplug = null) {
+    public static function send(string $data,  Payplug\Payplug $payplug = null) {
 
+        $data = json_decode($data,true);
         $httpClient = new Payplug\Core\HttpClient();
 
         return $response = $httpClient->post(
@@ -33,6 +34,80 @@ class PluginTelemetry
             $data,
             false
         );
+
+    }
+    /**
+     * this is a mock for send function
+     *
+     * @param string $data
+     * @param \Payplug\Payplug|null $payplug
+     * @return array
+     * @throws Exception\UnprocessableEntityException
+     */
+    public static function mockSend(string $data, Payplug\Payplug $payplug = null)
+    {
+        // Simulate API response
+        $data = json_decode($data, true);
+
+        self::validateData($data);
+
+        $responseData = array(
+            'id' => '64de13f259a577c644d0fb61',
+            'data' => $data
+        );
+        return array(
+            'httpStatus' => 201,
+            'httpResponse' => json_encode(
+                $responseData
+            )
+        );
+
+    }
+
+    /**
+     * Validate the $data and return UnprocessableEntityException
+     *
+     * @param array $data
+     * @throws Exception\UnprocessableEntityException
+     */
+    public static function validateData(array $data)
+    {
+        $requiredFields = array('version', 'php_version', 'name', 'source', 'domains', 'configurations', 'modules');
+
+        foreach ($requiredFields as $field) {
+            if (!isset($data[$field])) {
+                throw new Payplug\Exception\UnprocessableEntityException(
+                    'The server encountered an error while processing the request. The submitted data could not be processed.',
+                    '{"detail":[{"loc":["body","' . $field . '"],"msg":"field required","type":"value_error.missing"}]}',
+                    422
+                );
+            }
+        }
+        if (!is_array($data['domains']) || empty($data['domains']) || !isset($data['domains'][0]['url']) || !isset($data['domains'][0]['default'])) {
+            throw new Payplug\Exception\UnprocessableEntityException(
+                'The server encountered an error while processing the request. The submitted data could not be processed.',
+                '{"detail":[{"loc":["body","domains"],"msg":"invalid structure","type":"value_error.invalid_structure"}]}',
+                422
+            );
+        }
+
+        if (!is_array($data['configurations']) || empty($data['configurations']) || !isset($data['configurations']['name'])) {
+            throw new Payplug\Exception\UnprocessableEntityException(
+                'The server encountered an error while processing the request. The submitted data could not be processed.',
+                '{"detail":[{"loc":["body","configurations"],"msg":"invalid structure","type":"value_error.invalid_structure"}]}',
+                422
+            );
+        }
+
+        if (!is_array($data['modules']) || empty($data['modules']) || !isset($data['modules'][0]['name']) || !isset($data['modules'][0]['version'])) {
+            throw new Payplug\Exception\UnprocessableEntityException(
+                'The server encountered an error while processing the request. The submitted data could not be processed.',
+                '{"detail":[{"loc":["body","modules"],"msg":"invalid structure","type":"value_error.invalid_structure"}]}',
+                422
+            );
+        }
+
+
 
     }
 }

--- a/tests/unit_tests/PluginTelemetryTest.php
+++ b/tests/unit_tests/PluginTelemetryTest.php
@@ -49,10 +49,29 @@ class PluginTelemetryTest extends TestCase
         $result = $this->_httpClient->post(APIRoutes::$MERCHANT_PLUGINS_DATA_COLLECTOR_RESOURCE);
 
 
+        // Data to send to the MPDC microservice
         $data = array(
-            "version" => "4.0.0",
-            "php_version" => "8.2.1"
+            'version' => '4.0.0',
+            'php_version' => '8.2.1',
+            'name' => 'value',
+            'from' => 'save',
+            'domains' => array(
+                array(
+                    'url' => 'www.mywebsite.com',
+                    'default' => true
+                )
+            ),
+            'configurations' => array(
+                'name' => 'value'
+            ),
+            'modules' => array(
+                array(
+                    'name' => 'value',
+                    'version' => 'value'
+                )
+            )
         );
+        $data = json_encode($data);
 
         // call send and assert
         PluginTelemetry::send($data);

--- a/tests/unit_tests/PluginTelemetryTest.php
+++ b/tests/unit_tests/PluginTelemetryTest.php
@@ -1,0 +1,61 @@
+<?php
+
+
+namespace Payplug;
+use Payplug;
+use \Payplug\Core\HttpClient;
+use Payplug\Core\APIRoutes;
+use PHPUnit\Framework\TestCase;
+
+class PluginTelemetryTest extends TestCase
+{
+
+    private $_requestMock;
+    private $_httpClient;
+
+    /**
+     * @before
+     */
+    protected function setUpTest()
+    {
+        $this->_configuration = new Payplug\Payplug('abc');
+        $this->_httpClient = new HttpClient(new \Payplug\Payplug('abc'));
+        Payplug\Payplug::setDefaultConfiguration($this->_configuration);
+
+        $this->_requestMock = $this->createMock('Payplug\Core\IHttpRequest');
+        Payplug\Core\HttpClient::$REQUEST_HANDLER = $this->_requestMock;
+    }
+
+    /**
+     * Verify the behavior of send() method in the PluginTelemetry class
+     * with a mocked API URL that raises an exception
+     *
+     * @throws Exception\ConnectionException
+     * @throws Exception\HttpException
+     * @throws Exception\UnexpectedAPIResponseException
+     */
+    public function testSendWithBadMockedURL()
+    {
+        $this->expectException('Payplug\Exception\HttpException');
+        // Set a mocked MPDC API URL that will raise an exception
+        APIRoutes::setMerchantPluginsDataCollectorService('bad_mocked_mpdc_api_url');
+
+
+        // Mock the post method of the HTTP client
+        $this->_requestMock->expects($this->once())
+            ->method('exec')
+            ->will($this->returnValue('{"status":"not ok"}'));
+
+        $result = $this->_httpClient->post(APIRoutes::$MERCHANT_PLUGINS_DATA_COLLECTOR_RESOURCE);
+
+
+        $data = array(
+            "version" => "4.0.0",
+            "php_version" => "8.2.1"
+        );
+
+        // call send and assert
+        PluginTelemetry::send($data);
+
+    }
+}


### PR DESCRIPTION
## Pull Request: Implementing Data Storage Methods for Payplug-PHP Library

### Description
This pull request addresses JIRA ticket [PRE-1935](https://payplug-prod.atlassian.net/browse/PRE-1935) by introducing new methods in the `Payplug-PHP` library for recording simple data into the storage via the `plugin_telemetry` endpoint. The purpose of this update is to enhance the library's capabilities and provide a seamless way to interact with the endpoint for storing telemetry data.

### Changes Made
- Added new methods to the `Payplug` library  that enable the recording of simple data into the storage.
- Implemented communication with the `plugin_telemetry` endpoint to facilitate the data storage process.
- Included thorough unit tests to ensure the correctness of the new methods and their integration with the existing codebase.
- Mock the send method  of plugin_telemtry class for internal use
-  Update the readme.rst file in order to include the git workflow process.


[PRE-1935]: https://payplug-prod.atlassian.net/browse/PRE-1935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ