### PR TITLE
PRE-1935: fix configuration array check

### DIFF
--- a/lib/Payplug/PluginTelemetry.php
+++ b/lib/Payplug/PluginTelemetry.php
@@ -91,7 +91,7 @@ class PluginTelemetry
             );
         }
 
-        if (!is_array($data['configurations']) || empty($data['configurations']) || !isset($data['configurations']['name'])) {
+        if (!is_array($data['configurations']) || empty($data['configurations']) || !isset($data['configurations'][0]['name']) || !isset($data['configurations'][0]['value'])) {
             throw new Payplug\Exception\UnprocessableEntityException(
                 'The server encountered an error while processing the request. The submitted data could not be processed.',
                 '{"detail":[{"loc":["body","configurations"],"msg":"invalid structure","type":"value_error.invalid_structure"}]}',

--- a/tests/unit_tests/PluginTelemetryTest.php
+++ b/tests/unit_tests/PluginTelemetryTest.php
@@ -62,7 +62,10 @@ class PluginTelemetryTest extends TestCase
                 )
             ),
             'configurations' => array(
-                'name' => 'value'
+                array(
+                'name' => 'text1',
+                'value' => 'text2'
+                 )
             ),
             'modules' => array(
                 array(


### PR DESCRIPTION
# Pull Request: Update mock validateData Function to Accept "configurations" as Array with two fields(name and value)

## Description
This PR addresses the issue PRE-1935 where the validate mock is updated to check the "configurations" field as an array with two fields

## Changes Made
- Updated the function validateData  to check the field value of configuration array.
- Added validation to ensure that value and name fields exist
- Updated tests and mocks to reflect the new JSON format.


