### PR TITLE
PRE-2007: add bearer token to mpdc post

### DIFF
--- a/lib/Payplug/PluginTelemetry.php
+++ b/lib/Payplug/PluginTelemetry.php
@@ -27,12 +27,15 @@ class PluginTelemetry
     public static function send(string $data,  Payplug\Payplug $payplug = null) {
 
         $data = json_decode($data,true);
-        $httpClient = new Payplug\Core\HttpClient();
+        if ($payplug === null) {
+            $payplug = Payplug\Payplug::getDefaultConfiguration();
+        }
+
+        $httpClient = new Payplug\Core\HttpClient($payplug);
 
         return $response = $httpClient->post(
             Payplug\Core\APIRoutes::$MERCHANT_PLUGINS_DATA_COLLECTOR_RESOURCE,
-            $data,
-            false
+            $data
         );
 
     }


### PR DESCRIPTION
## Description

In this merge request, I've implemented changes within the `PluginTelemetry`class in the PayPlug library. The purpose of these modifications is to ensure that a bearer token is always included when making calls to the MPDC service. This enhancement has been introduced to establish a secure authentication process before storing data in the database.

## Changes Made


1. In the `send` method of the `PluginTelemetry`class, I removed the `false` parameter when calling the `post` method. This change ensures that authentication is always enabled, and a bearer token is included in the request header.
2. I have a adjusted the creation of the `HttpClient` object by using the default constructor and then updating the client using the provided PayPlug configuration if it is defined.

These changes will enable better control over calling the MPDC service and force the inclusion of a bearer token when needed for secure authentication.


