### PR TITLE
PRE-2258: Implement applepay method

### DIFF
--- a/lib/Payplug/Core/APIRoutes.php
+++ b/lib/Payplug/Core/APIRoutes.php
@@ -30,6 +30,7 @@ class APIRoutes
     const ONEY_PAYMENT_SIM_RESOURCE  = '/oney_payment_simulations';
     const ACCOUNTING_REPORT_RESOURCE = '/accounting_reports';
     const PUBLISHABLE_KEYS           = '/publishable_keys';
+    const UPD_APPLEPAY               = '/update-apple-payment';
 
 
 

--- a/lib/Payplug/Resource/Payment.php
+++ b/lib/Payplug/Resource/Payment.php
@@ -124,6 +124,30 @@ class Payment extends APIResource implements IVerifiableAPIResource
     }
 
     /**
+     * Aborts a ApplePay Payment.
+     *
+     * @param   Payplug\Payplug    $payplug    the client configuration
+     *
+     * @return  null|Payment the aborted payment or null on error
+     *
+     * @throws  Payplug\Exception\ConfigurationNotSetException
+     */
+    public function abortApplePay(Payplug\Payplug $payplug = null)
+    {
+        if ($payplug === null) {
+            $payplug = Payplug\Payplug::getDefaultConfiguration();
+        }
+
+        $httpClient = new Payplug\Core\HttpClient($payplug);
+        $response = $httpClient->patch(
+            Payplug\Core\APIRoutes::getRoute(Payplug\Core\APIRoutes::UPD_APPLEPAY, $this->id),
+            array('aborted' => true)
+        );
+
+        return Payment::fromAttributes($response['httpResponse']);
+    }
+
+    /**
      * Captures a Payment.
      * 
      * @param   Payplug\Payplug    $payplug    the client configuration
@@ -261,6 +285,30 @@ class Payment extends APIResource implements IVerifiableAPIResource
         $httpClient = new Payplug\Core\HttpClient($payplug);
         $response = $httpClient->patch(
             Payplug\Core\APIRoutes::getRoute(Payplug\Core\APIRoutes::PAYMENT_RESOURCE, $this->id),
+            $data
+        );
+
+        return Payment::fromAttributes($response['httpResponse']);
+    }
+
+    /**
+     * Update a ApplePay Payment.
+     *
+     * @param   array               $data       API data for payment creation
+     * @param   Payplug\Payplug    $payplug    the client configuration
+     *
+     * @return  null|Payment the updated payment instance
+     *
+     * @throws  Payplug\Exception\ConfigurationNotSetException
+     */
+    public function updateApplePay(array $data, Payplug\Payplug $payplug = null) {
+        if ($payplug === null) {
+            $payplug = Payplug\Payplug::getDefaultConfiguration();
+        }
+
+        $httpClient = new Payplug\Core\HttpClient($payplug);
+        $response = $httpClient->patch(
+            Payplug\Core\APIRoutes::getRoute(Payplug\Core\APIRoutes::UPD_APPLEPAY, $this->id),
             $data
         );
 

--- a/tests/unit_tests/Resource/PaymentTest.php
+++ b/tests/unit_tests/Resource/PaymentTest.php
@@ -474,6 +474,118 @@ class PaymentTest extends \PHPUnit\Framework\TestCase
         unset($GLOBALS['CURLOPT_POSTFIELDS_DATA']);
     }
 
+    public function testPaymentAbortApplePay()
+    {
+        $GLOBALS['CURLOPT_POSTFIELDS_DATA'] = null;
+
+        $this->_requestMock
+            ->expects($this->once())
+            ->method('exec')
+            ->will($this->returnValue('{"status":"ok"}'));
+
+        $this->_requestMock
+            ->expects($this->atLeastOnce())
+            ->method('setopt')
+            ->will($this->returnCallback(function($option, $value = null) {
+                switch($option) {
+                    case CURLOPT_POSTFIELDS:
+                        $GLOBALS['CURLOPT_POSTFIELDS_DATA'] = json_decode($value, true);
+                        return true;
+                }
+                return true;
+            }));
+        $this->_requestMock
+            ->expects($this->any())
+            ->method('getinfo')
+            ->will($this->returnCallback(function($option) {
+                switch($option) {
+                    case CURLINFO_HTTP_CODE:
+                        return 200;
+                }
+                return null;
+            }));
+
+        $payment = Payplug\Payment::abortApplePay('a_payment_id');
+
+        $this->assertTrue(is_array($GLOBALS['CURLOPT_POSTFIELDS_DATA']));
+        $this->assertTrue($GLOBALS['CURLOPT_POSTFIELDS_DATA'] === array('aborted' => true));
+        $this->assertEquals('ok', $payment->status);
+
+        unset($GLOBALS['CURLOPT_POSTFIELDS_DATA']);
+    }
+
+    public function testPaymentUpdateApplePay()
+    {
+        $GLOBALS['CURLOPT_POSTFIELDS_DATA'] = null;
+
+        $this->_requestMock
+            ->expects($this->once())
+            ->method('exec')
+            ->will($this->returnValue('{"status":"ok"}'));
+
+        $this->_requestMock
+            ->expects($this->atLeastOnce())
+            ->method('setopt')
+            ->will($this->returnCallback(function($option, $value = null) {
+                switch($option) {
+                    case CURLOPT_POSTFIELDS:
+                        $GLOBALS['CURLOPT_POSTFIELDS_DATA'] = json_decode($value, true);
+                        return true;
+                }
+                return true;
+            }));
+        $this->_requestMock
+            ->expects($this->any())
+            ->method('getinfo')
+            ->will($this->returnCallback(function($option) {
+                switch($option) {
+                    case CURLINFO_HTTP_CODE:
+                        return 200;
+                }
+                return null;
+            }));
+
+        $payment = Payment::updateApplePay(array(
+            'amount'            => 999,
+            'payment_token'     => 'applepay_payment_token',
+            'billing'           => array(
+                'administrativeArea' => 'Île-de-France',
+                'country' => 'France',
+                'countryCode' => 'FR',
+                'emailAddress' => 'name@customer.net',
+                'familyName' => 'Doe',
+                'givenName' => 'John',
+                'locality' => 'Paris',
+                'phoneNumber' => '0123456789',
+                'phoneticFamilyName' => '',
+                'phoneticGivenName' => '',
+                'postalCode' => '75009',
+                'subAdministrativeArea' => 'Paris',
+                'subLocality' => '9e Arr.',
+            ),
+            'shipping'          => array(
+                'administrativeArea' => 'Île-de-France',
+                'country' => 'France',
+                'countryCode' => 'FR',
+                'emailAddress' => 'name@customer.net',
+                'familyName' => 'Doe',
+                'givenName' => 'John',
+                'locality' => 'Paris',
+                'phoneNumber' => '0123456789',
+                'phoneticFamilyName' => '',
+                'phoneticGivenName' => '',
+                'postalCode' => '75009',
+                'subAdministrativeArea' => 'Paris',
+                'subLocality' => '9e Arr.',
+            ),
+        ));
+
+        $this->assertTrue(is_array($GLOBALS['CURLOPT_POSTFIELDS_DATA']));
+        $this->assertEquals('ok', $payment->status);
+
+        unset($GLOBALS['CURLOPT_POSTFIELDS_DATA']);
+    }
+
     public function testPaymentCapture()
     {
         $GLOBALS['CURLOPT_POSTFIELDS_DATA'] = null;


### PR DESCRIPTION
## Description

For the apple pay usage on shopping cart and product pages, we need to implement few method to patch the payment resource amount and user information (billing/shipping adresses)

## Changes Made

1. Create a new route to patch applepay payment resource
2. Add two new methods to abort and patch payment resource


