### PR TITLE
Pay1908 check secret key

### DIFF
--- a/lib/Payplug/Authentication.php
+++ b/lib/Payplug/Authentication.php
@@ -46,6 +46,10 @@ class Authentication
             $payplug = Payplug::getDefaultConfiguration();
         }
 
+        if (!isset($payplug->getToken()) || empty($payplug->getToken()) {
+            throw new Exception\ConfigurationException('Expected string values for the token.');
+        }
+        
         $httpClient = new Core\HttpClient($payplug);
         $response = $httpClient->get(Core\APIRoutes::getRoute(Core\APIRoutes::ACCOUNT_RESOURCE));
 
@@ -66,6 +70,10 @@ class Authentication
         if ($payplug === null) {
             $payplug = Payplug::getDefaultConfiguration();
         }
+
+        if (!isset($payplug->getToken()) || empty($payplug->getToken()) {
+            throw new Exception\ConfigurationException('Expected string values for the token.');
+        }        
 
         $httpClient = new Core\HttpClient($payplug);
         $response = $httpClient->get(Core\APIRoutes::getRoute(Core\APIRoutes::ACCOUNT_RESOURCE));

--- a/lib/Payplug/Authentication.php
+++ b/lib/Payplug/Authentication.php
@@ -46,7 +46,8 @@ class Authentication
             $payplug = Payplug::getDefaultConfiguration();
         }
 
-        if (!isset($payplug->getToken()) || empty($payplug->getToken()) {
+        $token = $payplug->getToken();
+        if (!isset($token) || empty($token)) {
             throw new Exception\ConfigurationException('Expected string values for the token.');
         }
         
@@ -71,9 +72,10 @@ class Authentication
             $payplug = Payplug::getDefaultConfiguration();
         }
 
-        if (!isset($payplug->getToken()) || empty($payplug->getToken()) {
+        $token = $payplug->getToken();
+        if (!isset($token) || empty($token)) {
             throw new Exception\ConfigurationException('Expected string values for the token.');
-        }        
+        }      
 
         $httpClient = new Core\HttpClient($payplug);
         $response = $httpClient->get(Core\APIRoutes::getRoute(Core\APIRoutes::ACCOUNT_RESOURCE));

--- a/tests/unit_tests/AuthenticationTest.php
+++ b/tests/unit_tests/AuthenticationTest.php
@@ -2,6 +2,7 @@
 namespace Payplug;
 use Payplug;
 use Payplug\Core\HttpClient;
+use PayPlug\Exception\ConfigurationException;
 
 /**
 * @group unit

--- a/tests/unit_tests/AuthenticationTest.php
+++ b/tests/unit_tests/AuthenticationTest.php
@@ -106,6 +106,12 @@ class AuthenticationTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('12345', $account['httpResponse']['id']);
     }
 
+    public function testGetAccountWithoutSecretKey()
+    {
+        $this->expectException('\PayPlug\Exception\ConfigurationException');
+        Authentication::getAccount();
+    }
+    
     public function testGetPermissions()
     {
         $response = array(
@@ -149,6 +155,12 @@ class AuthenticationTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(false, $permissions['can_create_installment_plan']);
         $this->assertEquals(false, $permissions['can_save_cards']);
     }
+
+    public function testGetPermissionsWithoutSecretKey()
+    {
+        $this->expectException('\PayPlug\Exception\ConfigurationException');
+        Authentication::getPermissions();
+    }    
 
     public function testPublishableKeys()
     {


### PR DESCRIPTION
To avoid unnecessary and numerous calls to the Resource /Liver that end up, we check the presence of the secret key before making the call to the webservice