### PR TITLE
PRE-2607: check if secret key is empty

### DIFF
--- a/.github/workflows/payplug-ci.yml
+++ b/.github/workflows/payplug-ci.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           projectBaseDir: .
           args: >
-            -Dsonar.organization=${{ secrets.SONAR_ORGA }}
+            -Dsonar.organization=${{ vars.SONAR_ORGANIZATION }}
             -Dsonar.projectKey=github-payplug-payplug-php
             -Dsonar.sources=lib/
             -Dsonar.test.exclusions=tests/**

--- a/lib/Payplug/Authentication.php
+++ b/lib/Payplug/Authentication.php
@@ -2,6 +2,7 @@
 namespace Payplug;
 
 use Exception;
+use Payplug\Exception\ConfigurationException;
 
 /**
  * The Authentication DAO simplifies the access to most useful customer methods
@@ -39,12 +40,14 @@ class Authentication
      * @return  null|array the account settings
      *
      * @throws  Exception\ConfigurationNotSetException
+     * @throws ConfigurationException
      */
     public static function getAccount(Payplug $payplug = null)
     {
         if ($payplug === null) {
             $payplug = Payplug::getDefaultConfiguration();
         }
+        self::validateToken($payplug);
 
         $httpClient = new Core\HttpClient($payplug);
         $response = $httpClient->get(Core\APIRoutes::getRoute(Core\APIRoutes::ACCOUNT_RESOURCE));
@@ -55,17 +58,20 @@ class Authentication
     /**
      * Retrieve the account permissions
      *
-     * @param   Payplug $payplug the client configuration
+     * @param  Payplug $payplug the client configuration
      *
      * @return  null|array the account permissions
      *
      * @throws  Exception\ConfigurationNotSetException
+     * @throws ConfigurationException
      */
     public static function getPermissions(Payplug $payplug = null)
     {
         if ($payplug === null) {
             $payplug = Payplug::getDefaultConfiguration();
         }
+
+        self::validateToken($payplug);
 
         $httpClient = new Core\HttpClient($payplug);
         $response = $httpClient->get(Core\APIRoutes::getRoute(Core\APIRoutes::ACCOUNT_RESOURCE));
@@ -78,12 +84,13 @@ class Authentication
      * This function is for user-friendly interface purpose only.
      * You should probably not use this more than once, login/password MUST NOT be stored and API Keys are enough to interact with API.
      *
-     * @param   string $email the user email
-     * @param   string $password the user password
+     * @param string $email the user email
+     * @param string $password the user password
      *
      * @return  null|array the account permissions
      *
      * @throws  Exception\ConfigurationNotSetException
+     * @throws ConfigurationException
      */
     public static function getPermissionsByLogin($email, $password)
     {
@@ -92,6 +99,7 @@ class Authentication
             'secretKey' => $keys['httpResponse']['secret_keys']['live'],
             'apiVersion' => null,
         ));
+        self::validateToken($payplug);
 
         $httpClient = new Core\HttpClient($payplug);
         $response = $httpClient->get(Core\APIRoutes::getRoute(Core\APIRoutes::ACCOUNT_RESOURCE));
@@ -119,6 +127,21 @@ class Authentication
             return $response;
         } catch (Exception $e) {
             return false;
+        }
+    }
+
+    /**
+     * Validates the Payplug token
+     *
+     * @param Payplug $payplug
+     * @return void
+     * @throws ConfigurationException
+     */
+    private static function validateToken(Payplug $payplug)
+    {
+        $token = $payplug->getToken();
+        if (empty($token)) {
+            throw new ConfigurationException('The Payplug configuration requires a valid token.');
         }
     }
 }

--- a/tests/unit_tests/AuthenticationTest.php
+++ b/tests/unit_tests/AuthenticationTest.php
@@ -2,6 +2,7 @@
 namespace Payplug;
 use Payplug;
 use Payplug\Core\HttpClient;
+use Payplug\Exception\ConfigurationException;
 
 /**
 * @group unit
@@ -106,6 +107,22 @@ class AuthenticationTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('12345', $account['httpResponse']['id']);
     }
 
+    /**
+     *  Tests the getAccount method when no secret key is provided.
+     *
+     * @return void
+     * @throws ConfigurationException
+     */
+    public function testGetAccountWithoutSecretKey()
+    {
+        $payplug = new \Payplug\Payplug('');
+        Payplug\Payplug::setDefaultConfiguration($payplug);
+
+        $this->expectException('\Payplug\Exception\ConfigurationException');
+        $this->expectExceptionMessage('The Payplug configuration requires a valid token.');
+
+        Authentication::getAccount();
+    }
     public function testGetPermissions()
     {
         $response = array(
@@ -149,6 +166,23 @@ class AuthenticationTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(false, $permissions['can_create_installment_plan']);
         $this->assertEquals(false, $permissions['can_save_cards']);
     }
+
+
+    /**
+     * Tests the getPermissions method when no secret key is provided.
+     * @return void
+     * @throws ConfigurationException
+     */
+    public function testGetPermissionsWithoutSecretKey()
+    {
+        $payplug = new \Payplug\Payplug('');
+        Payplug\Payplug::setDefaultConfiguration($payplug);
+
+        $this->expectException('\PayPlug\Exception\ConfigurationException');
+        $this->expectExceptionMessage('The Payplug configuration requires a valid token.');
+        Authentication::getPermissions();
+    }
+
 
     public function testPublishableKeys()
     {


### PR DESCRIPTION
**Description**

The purpose of these modifications is to ensure that the getAccount and getPermissions methods correctly handle cases where a valid token is not provided in the configuration. 

**Changes Made**
 - Added extra check to getAccount and getPermissions to throw a ConfigurationException when they are called with an empty token in the Payplug configuration
- Cover these changes with unit tests