### PR TITLE
PRE-2604: get the client id and scret mask from user-manager

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -128,7 +128,7 @@ Git Workflow Steps
 
        git checkout master
        git pull origin master
-       git tag -a v<version-number> -m "Release <version-number>"
+       git tag -a <version-number> -m "Release <version-number>"
        git push origin master --tags
 
 Usage

--- a/lib/Payplug/Core/APIRoutes.php
+++ b/lib/Payplug/Core/APIRoutes.php
@@ -18,6 +18,11 @@ class APIRoutes
      */
     public static $MERCHANT_PLUGINS_DATA_COLLECTOR_RESOURCE;
 
+    /**
+     * @var string the root URL of the User Manager microService
+     */
+    public static $USER_MANAGER_RESOURCE;
+
     const API_VERSION = 1;
 
     // Resources routes
@@ -78,6 +83,15 @@ class APIRoutes
     }
 
     /**
+     * @description set $USER_MANAGER_RESOURCE from plugin
+     * @param $microServiceBaseUrl
+     */
+    public static function setUserManagerResource($microServiceBaseUrl)
+    {
+        self::$USER_MANAGER_RESOURCE = $microServiceBaseUrl;
+    }
+
+    /**
      * Gets a route that allows to check whether the remote API is up.
      *
      * @return  string  the full URL to the test resource
@@ -90,4 +104,5 @@ class APIRoutes
 
 APIRoutes::$API_BASE_URL = 'https://api.payplug.com';
 APIRoutes::$MERCHANT_PLUGINS_DATA_COLLECTOR_RESOURCE = 'Microservice Url';
+APIRoutes::$USER_MANAGER_RESOURCE ='User manager resource';
 

--- a/lib/Payplug/Core/HttpClient.php
+++ b/lib/Payplug/Core/HttpClient.php
@@ -122,9 +122,9 @@ class HttpClient
      * @throws  Payplug\Exception\HttpException                   When status code is not 2xx.
      * @throws  Payplug\Exception\ConnectionException             When an error was encountered while connecting to the resource.
      */
-    public function get($resource, $data = null)
+    public function get($resource, $data = null, $cookie=null)
     {
-        return $this->request('GET', $resource, $data);
+        return $this->request('GET', $resource, $data, true, $cookie);
     }
 
     /**
@@ -226,7 +226,7 @@ class HttpClient
      * @throws  Payplug\Exception\HttpException                   When status code is not 2xx.
      * @throws  Payplug\Exception\ConnectionException             When an error was encountered while connecting to the resource.
      */
-    private function request($httpVerb, $resource, array $data = null, $authenticated = true)
+    private function request($httpVerb, $resource, array $data = null, $authenticated = true, $cookie = null)
     {
         if (self::$REQUEST_HANDLER === null) {
             $request = new CurlRequest();
@@ -246,6 +246,10 @@ class HttpClient
             $headers[] = 'PayPlug-Version: ' . $this->_configuration->getApiVersion();
         }
 
+        if (!empty($cookie)) {
+            $headers[] = 'Cookie:' . $cookie;
+        }
+
         $request->setopt(CURLOPT_FAILONERROR, false);
         $request->setopt(CURLOPT_RETURNTRANSFER, true);
         $request->setopt(CURLOPT_CUSTOMREQUEST, $httpVerb);
@@ -254,6 +258,7 @@ class HttpClient
         $request->setopt(CURLOPT_SSL_VERIFYPEER, true);
         $request->setopt(CURLOPT_SSL_VERIFYHOST, 2);
         $request->setopt(CURLOPT_CAINFO, self::$CACERT_PATH);
+        $request->setopt(CURLOPT_FOLLOWLOCATION, true);
         if (!empty($data)) {
             $request->setopt(CURLOPT_POSTFIELDS, json_encode($data));
         }

--- a/tests/unit_tests/AuthenticationTest.php
+++ b/tests/unit_tests/AuthenticationTest.php
@@ -211,4 +211,101 @@ class AuthenticationTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(200, $publishable_keys['httpStatus']);
         $this->assertEquals('pk_test_everythingIsUnderControl', $publishable_keys['httpResponse']['publishable_key']);
     }
+
+    /**
+     * Test the getClientIdAndSecretMask method.
+     *
+     * This test verifies that the getClientData method correctly retrieves
+     * the client_id, client_secret_mask , client_name client_type and mode from the user manager resource.
+     *
+     * @throws \Exception
+     */
+    public function testGetClientData()
+    {
+        $response = array(
+            array(
+                'client_id' => 'test_client_id',
+                'client_secret_mask' => 'test_secret_mask',
+                'client_name' => 'test_client_name',
+                'client_type' => 'test_client_type',
+                'mode' => 'test_mode',
+            ),
+        );
+
+        $this->_requestMock
+            ->expects($this->once())
+            ->method('exec')
+            ->will($this->returnValue(json_encode($response)));
+
+        $this->_requestMock
+            ->expects($this->any())
+            ->method('getinfo')
+            ->will($this->returnCallback(function($option) {
+                switch($option) {
+                    case CURLINFO_HTTP_CODE:
+                        return 200;
+                }
+                return null;
+            }));
+
+        $session = 'test_session_value';
+        $result = Authentication::getClientData($session, $this->_configuration);
+        $this->assertCount(1, $result);
+        $this->assertEquals('test_client_id', $result[0]['client_id']);
+        $this->assertEquals('test_secret_mask', $result[0]['client_secret_mask']);
+        $this->assertEquals('test_client_name', $result[0]['client_name']);
+        $this->assertEquals('test_client_type', $result[0]['client_type']);
+        $this->assertEquals('test_mode', $result[0]['mode']);
+
+    }
+
+    /**
+     * Test the createClientIdAndSecret correctly creates
+     *  a client ID and client secret.
+     *
+     * @throws \Exception
+     */
+    public function testCreateClientIdAndSecret()
+    {
+        $response = array(
+        array(
+                'client_id' => 'test_client_id',
+                'client_secret' => 'test_client_secret',
+            ),
+        );
+
+        $this->_requestMock
+            ->expects($this->once())
+            ->method('exec')
+            ->will($this->returnValue(json_encode($response)));
+
+        $this->_requestMock
+            ->expects($this->any())
+            ->method('getinfo')
+            ->will($this->returnCallback(function($option) {
+                switch($option) {
+                    case CURLINFO_HTTP_CODE:
+                        return 200;
+                }
+                return null;
+            }));
+        $session = 'test_session_value';
+        $company_id = 'test_company_id';
+        $client_name = 'test_client_name';
+        $mode = 'test';
+        $result = Authentication::createClientIdAndSecret($company_id, $client_name, $mode, $session, $this->_configuration);
+        $this->assertCount(1, $result);
+        $this->assertEquals('test_client_id', $result[0]['client_id']);
+        $this->assertEquals('test_client_secret', $result[0]['client_secret']);
+    }
+
+    /**
+     * Test the setKratosSession method with a null session.
+     */
+    public function testSetKratosSessionNull()
+    {
+        $this->expectException('\PayPlug\Exception\ConfigurationException');
+        $this->expectExceptionMessage('The session value must be set.');
+        Authentication::setKratosSession(null);
+    }
 }


### PR DESCRIPTION
### Description
Retrieve `client_id` and `client_secret_mask` from the user manager using the Kratos session.

### Changes Made

#### Authentication.php Updates
- **Method: `getClientIdAndSecretMask()`**:
  - Added to retrieve `client_id` and `client_secret_mask` from the user manager resource, utilizing the session cookie for authentication.

- **Method: `setKratosSession()`**:
  - Added to create the session cookie string. This method should be called from the plugin to set its value.

#### HttpClient.php Updates
- **Method: `get()`**:
  - Added a `$cookie` parameter to allow passing session cookies directly in the request.

- **Method: `request()`**:
  - Modified to accept and set the cookie in the HTTP headers for requests. This ensures that the correct session information is sent with the user manager call.
  - Included `CURLOPT_FOLLOWLOCATION` to ensure that the client follows HTTP redirects automatically, which is important for functionality.

#### APIRoutes.php Updates
- Added `$USER_MANAGER_RESOURCE`.
- Added `setUserManagerResource()` to be called inside plugins to set the value of `$USER_MANAGER_RESOURCE` in an environment test.

#### Testing
- Covered `getClientIdAndSecretMask()` with unit tests.