### PR TITLE
[Authentication] Fix return type for getRegisterUrl

### DIFF
--- a/lib/Payplug/Authentication.php
+++ b/lib/Payplug/Authentication.php
@@ -293,7 +293,7 @@ class Authentication
      * @param string $setup_redirection_uri
      * @param string $oauth_callback_uri
      *
-     * @return array
+     * @return string
      * @throws Exception\ConnectionException
      * @throws Exception\HttpException
      * @throws Exception\UnexpectedAPIResponseException


### PR DESCRIPTION
Hello ! 

I just noticed that the docblock was incorrect for getRegisterUrl(), it return the route as string, not an array. 

Thanks